### PR TITLE
feature: Add WTM support for Oracle

### DIFF
--- a/demo/WalkingTec.Mvvm.Demo/ViewModels/DataTableVMs/ActionLogListVM.cs
+++ b/demo/WalkingTec.Mvvm.Demo/ViewModels/DataTableVMs/ActionLogListVM.cs
@@ -41,11 +41,14 @@ namespace WalkingTec.Mvvm.Demo.ViewModels.DataTableVMs
             switch (ConfigInfo.DbType)
             {
                 case DBTypeEnum.MySql:
+                case DBTypeEnum.PgSql:
+                case DBTypeEnum.SQLite:
                     sql = string.Format("SELECT id, itcode as test1, modulename as test2 from actionlogs limit 10"); break;
                 case DBTypeEnum.SqlServer:
                     sql = string.Format("SELECT top 10 id, itcode as test1, modulename as test2 from actionlogs"); break;
+                case DBTypeEnum.Oracle:
+                    sql = string.Format("SELECT id, itcode as test1, modulename as test2 from actionlogs fetch next 10 rows only"); break;
             }
-
             var cmd = DC.Database.GetDbConnection().CreateCommand();
             cmd.CommandText = sql;
             cmd.CommandType = CommandType.Text;

--- a/src/WalkingTec.Mvvm.Core/DataContext.cs
+++ b/src/WalkingTec.Mvvm.Core/DataContext.cs
@@ -1,8 +1,10 @@
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.Extensions.Logging;
 using MySql.Data.MySqlClient;
 using Npgsql;
+using Oracle.ManagedDataAccess.Client;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -310,6 +312,9 @@ namespace WalkingTec.Mvvm.Core
                 case DBTypeEnum.SQLite:
                     optionsBuilder.UseSqlite(CSName);
                     break;
+                case DBTypeEnum.Oracle:
+                    optionsBuilder.UseOracle(CSName);
+                    break;
                 default:
                     break;
             }
@@ -603,7 +608,34 @@ namespace WalkingTec.Mvvm.Core
                         npgCon.Close();
                     }
                     break;
-
+                case DBTypeEnum.SQLite:
+                case DBTypeEnum.Oracle:
+                    var connection = this.Database.GetDbConnection();
+                    var isClosed = connection.State == ConnectionState.Closed;
+                    if (isClosed)
+                    {
+                        connection.Open();
+                    }
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = sql;
+                        command.CommandTimeout = 2400;
+                        command.CommandType = commandType;
+                        if (paras != null)
+                        {
+                            foreach (var param in paras)
+                                command.Parameters.Add(param);
+                        }
+                        using (var reader = command.ExecuteReader())
+                        {
+                            table.Load(reader);
+                        }
+                    }
+                    if (isClosed)
+                    {
+                        connection.Close();
+                    }
+                    break;
             }
             return table;
         }
@@ -632,6 +664,12 @@ namespace WalkingTec.Mvvm.Core
                     break;
                 case DBTypeEnum.PgSql:
                     rv = new NpgsqlParameter(name, value) { Direction = dir };
+                    break;
+                case DBTypeEnum.SQLite:
+                    rv = new SqliteParameter(name, value) { Direction = dir };
+                    break;
+                case DBTypeEnum.Oracle:
+                    rv = new OracleParameter(name, value) { Direction = dir };
                     break;
             }
             return rv;

--- a/src/WalkingTec.Mvvm.Core/Enums.cs
+++ b/src/WalkingTec.Mvvm.Core/Enums.cs
@@ -26,17 +26,17 @@ namespace WalkingTec.Mvvm.Core
     /// <summary>
     /// 数据库类型
     /// </summary>
-    public enum DBTypeEnum { SqlServer, MySql, PgSql,Memory, SQLite }
+    public enum DBTypeEnum { SqlServer, MySql, PgSql, Memory, SQLite, Oracle }
 
     /// <summary>
     /// 页面显示方式
     /// </summary>
-    public enum PageModeEnum { Single, Tab}
+    public enum PageModeEnum { Single, Tab }
 
     /// <summary>
     /// Tab页的显示方式
     /// </summary>
-    public enum TabModeEnum { Default, Simple}
+    public enum TabModeEnum { Default, Simple }
 
     /// <summary>
     /// Notification出现的位置

--- a/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
+++ b/src/WalkingTec.Mvvm.Core/WalkingTec.Mvvm.Core.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.4" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.2.0" />
+    <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.30" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
feature: Add WTM support for Oracle

Note: Oracle database version 18c is required.
> [Oracle Data Provider for .NET – Microsoft .NET Core and Entity Framework Core](https://www.oracle.com/technetwork/topics/dotnet/tech-info/odpnet-dotnet-ef-core-sod-4395108.pdf): Oracle released a beta version of ODP.NET Core in February 2018. Oracle plans to release a production version of ODP.NET Core during the third quarter of 2018 at the same time as Oracle Data Access Components (ODAC) 18c.