### PR TITLE
PersistPoco DoDelete issue

### DIFF
--- a/src/WalkingTec.Mvvm.Core/BaseCRUDVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BaseCRUDVM.cs
@@ -637,7 +637,9 @@ namespace WalkingTec.Mvvm.Core
                 (Entity as PersistPoco).IsValid = false;
                 (Entity as PersistPoco).UpdateTime = DateTime.Now;
                 (Entity as PersistPoco).UpdateBy = LoginUserInfo?.ITCode;
-                DC.UpdateEntity(Entity);
+                DC.UpdateProperty(Entity, "IsValid");
+                DC.UpdateProperty(Entity, "UpdateTime");
+                DC.UpdateProperty(Entity, "UpdateBy");
                 try
                 {
                     DC.SaveChanges();
@@ -662,7 +664,9 @@ namespace WalkingTec.Mvvm.Core
                 (Entity as PersistPoco).IsValid = false;
                 (Entity as PersistPoco).UpdateTime = DateTime.Now;
                 (Entity as PersistPoco).UpdateBy = LoginUserInfo?.ITCode;
-                DC.UpdateEntity(Entity);
+                DC.UpdateProperty(Entity, "IsValid");
+                DC.UpdateProperty(Entity, "UpdateTime");
+                DC.UpdateProperty(Entity, "UpdateBy");
                 try
                 {
                     await DC.SaveChangesAsync();


### PR DESCRIPTION
The instance of entity type 'X' cannot be tracked because another instance with the same key value for {'ID'} is already being tracked. When attaching existing entities, ensure that only one entity instance with a given key value is attached.