### PR TITLE
添加RadioType类型至wt:grid，缺省为false

### DIFF
--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/DataTableTagHelper.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/DataTableTagHelper.cs
@@ -126,6 +126,10 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
         /// </summary>
         public bool HiddenCheckbox { get; set; }
         /// <summary>
+        /// 设定列类型是否Radio类型 默认false
+        /// </summary>
+        public bool RadioType { get; set; }
+        /// <summary>
         /// 设定复选框列 默认false
         /// </summary>
         public bool HiddenGridIndex { get; set; }
@@ -439,7 +443,8 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
                     UnResize = true,
                     //Width = 45
                 };
-                if(LineHeight != null)
+                if (RadioType) checkboxHeader.Type = LayuiColumnTypeEnum.Radio;
+                if (LineHeight != null)
                 {
                     checkboxHeader.Style = $"height:{LineHeight}px";
                 }

--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/Models/LayuiColumn.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/Models/LayuiColumn.cs
@@ -19,6 +19,10 @@ namespace WalkingTec.Mvvm.TagHelpers.LayUI
         /// </summary>
         Checkbox,
         /// <summary>
+        /// 单选框列
+        /// </summary>
+        Radio,
+        /// <summary>
         /// 空列
         /// </summary>
         Space,


### PR DESCRIPTION
现在的wt:grid只能支持多选模式，一些场景下使用不便。
添加RadioType类型至wt:grid，可以为wt:grid增加单选样式。