### PR TITLE
Update DataTableTagHelper.cs

### DIFF
--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/DataTableTagHelper.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/DataTableTagHelper.cs
@@ -569,7 +569,7 @@ layui.use(['table'], function(){{
       if(res.Code == 401){{ layui.layer.confirm(res.Msg,{{title:'{THProgram._localizer["Sys.Error"]}'}}, function(index){{window.location.reload();layer.close(index);}});}}
       if(res.Code != undefined && res.Code != 200){{ layui.layer.alert(res.Msg,{{title:'{THProgram._localizer["Sys.Error"]}'}});}}
      var tab = $('#{Id} + .layui-table-view');tab.find('table').css('border-collapse','separate');
-      {(Height == null ? $"tab.css('overflow','hidden').addClass('donotuse_fill donotuse_pdiv');tab.children('.layui-table-box').addClass('donotuse_fill donotuse_pdiv').css('height','100px');tab.find('.layui-table-main').addClass('donotuse_fill');tab.find('.layui-table-header').css('min-height','{maxDepth*38}px');ff.triggerResize();" : string.Empty)}
+      {(Height == null ? $"tab.css('overflow','hidden').addClass('donotuse_fill donotuse_pdiv');tab.children('.layui-table-box').addClass('donotuse_fill donotuse_pdiv').css('height','100px');tab.find('.layui-table-main').addClass('donotuse_fill');tab.find('.layui-table-header');ff.triggerResize();" : string.Empty)}
       {(MultiLine == true ? $"tab.find('.layui-table-cell').css('height','auto').css('white-space','normal');" : string.Empty)}
        tab.find('div [lay-event=\'LAYTABLE_COLS\']').attr('title','{THProgram._localizer["Sys.ColumnFilter"]}');
        tab.find('div [lay-event=\'LAYTABLE_PRINT\']').attr('title','{THProgram._localizer["Sys.Print"]}');


### PR DESCRIPTION
当<wt:Grid>不设置高度，且设定size="DataTableSizeEnum.LG"或size="DataTableSizeEnum.SM"时，表格头高度不正确，如果有ActionColumn时，ActionColumn的高度会与表格错位。取消调.css('min-height',38)就好了