### PR TITLE
Update BasePagedListVM.cs

### DIFF
--- a/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs
+++ b/src/WalkingTec.Mvvm.Core/BasePagedListVM.cs
@@ -1011,11 +1011,11 @@ namespace WalkingTec.Mvvm.Core
                 var temp = GridHeaders as List<GridColumn<TModel>>;
                 if (temp.Where(x => x.ColumnType == GridColumnTypeEnum.Action).FirstOrDefault() == null)
                 {
-                    temp.Add(this.MakeGridColumn(x => x.BatchError, Width: 200, Header: Core.CoreProgram._localizer?["Sys.Error"]).SetForeGroundFunc(x => "ff0000"));
+                    temp.Add(this.MakeGridColumn(x => x.BatchError, Width: 200, Header: Core.CoreProgram._localizer?["Sys.Error"]).SetForeGroundFunc(x => "ff0000").SetFixed(GridColumnFixedEnum.Right));
                 }
                 else
                 {
-                    temp.Insert(temp.Count - 1, this.MakeGridColumn(x => x.BatchError, Width: 200, Header: Core.CoreProgram._localizer?["Sys.Error"]).SetForeGroundFunc(x => "ff0000"));
+                    temp.Insert(temp.Count - 1, this.MakeGridColumn(x => x.BatchError, Width: 200, Header: Core.CoreProgram._localizer?["Sys.Error"]).SetForeGroundFunc(x => "ff0000").SetFixed(GridColumnFixedEnum.Right));
                 }
             }
         }


### PR DESCRIPTION
让AddErrorColumn()增加的错误信息列，固定在表格的右侧，不然表格列数太多时，错误信息被推到屏幕外，用户有一种提交失败但不提示的感觉