### PR TITLE
#529 Fix:DataTableTagHelper can not BindVisiableColName Boolean

### DIFF
--- a/src/WalkingTec.Mvvm.TagHelpers.LayUI/DataTableTagHelper.cs
+++ b/src/WalkingTec.Mvvm.TagHelpers.LayUI/DataTableTagHelper.cs
@@ -780,7 +780,7 @@ setTimeout(function(){{
                         bool condition = false || string.IsNullOrEmpty(item.BindVisiableColName) == false;
                         if (condition == true)
                         {
-                            rowBtnStrBuilder.Append("{{#  if(d." + item.BindVisiableColName + " == true || d." + item.BindVisiableColName + " == 'true' ){ }}");
+                            rowBtnStrBuilder.Append("{{#  if(d." + item.BindVisiableColName + " == true || d." + item.BindVisiableColName + " == 'true' || d." + item.BindVisiableColName + " == 'True' ){ }}");
                         }
                         rowBtnStrBuilder.Append($@"<a class=""layui-btn {(string.IsNullOrEmpty(item.ButtonClass) ? "layui-btn-primary" : $"{item.ButtonClass}")} layui-btn-xs"" lay-event=""{item.Area + item.ControllerName + item.ActionName + item.QueryString}"">{item.Name}</a>");
                         if (condition == true)


### PR DESCRIPTION
if use like this,

this.MakeGridHeader(x => "CanEdit").SetFormat((e,v)=>true),
it's no work!
because framework require back "true" not true
https://github.com/dotnetcore/WTM/issues/529