### PR TITLE
add a new  Attribute:[HiddenApiFilter.HideApi] to hide some api in sw…

### DIFF
--- a/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/FrameworkServiceExtension.cs
@@ -623,6 +623,7 @@ namespace WalkingTec.Mvvm.Mvc
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+                c.DocumentFilter<HiddenApiFilter>();
                 var bearer = new OpenApiSecurityScheme()
                 {
                     Description = "JWT Bearer",

--- a/src/WalkingTec.Mvvm.Mvc/Helper/HiddenApiFilter.cs
+++ b/src/WalkingTec.Mvvm.Mvc/Helper/HiddenApiFilter.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+namespace WalkingTec.Mvvm.Mvc.Helper
+{ 
+    public class HiddenApiFilter : IDocumentFilter
+    {
+        /// <summary>
+        /// 隐藏swagger接口特性标识
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+        public class HideApiAttribute : System.Attribute
+        {
+        }
+
+
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            foreach (ApiDescription description in context.ApiDescriptions)
+            {
+                if (description.TryGetMethodInfo(out MethodInfo method))
+                {
+                    if (method.ReflectedType.CustomAttributes.Any(t => t.AttributeType == typeof(HideApiAttribute))
+                            || method.CustomAttributes.Any(t => t.AttributeType == typeof(HideApiAttribute)))
+                    {
+                        string key = "/" + description.RelativePath;
+                        if (key.Contains("?"))
+                        {
+                            int idx = key.IndexOf("?", System.StringComparison.Ordinal);
+                            key = key.Substring(0, idx);
+                        }
+                        swaggerDoc.Paths.Remove(key);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
框架自动生成了很多API，部分API可能不想公开给第三方， 就可以增加这个标签  [HiddenApiFilter.HideApi] 在Controllers 
这样生成swagger文档的时候就可以过滤掉